### PR TITLE
Remove Crystal namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Look at the spec for most functions
 
 ```crystal
 require "crystal-fann"
-ann = Crystal::Fann::Network::Standard.new(2, [2], 1)
+ann = Fann::Network::Standard.new(2, [2], 1)
 500.times do
   ann.train_single([1.0, 0.1], [0.5])
 end
@@ -33,10 +33,10 @@ ann.close
 
 ```crystal
 # Work on array of test data (batch)
-ann = Crystal::Fann::Network::Standard.new(2, [3], 1)
+ann = Fann::Network::Standard.new(2, [3], 1)
 input = [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
 output = [[0.0], [1.0], [1.0], [0.0]]
-train_data = Crystal::Fann::TrainData.new(input, output)
+train_data = Fann::TrainData.new(input, output)
 data = train_data.train_data
 ann.train_algorithem(LibFANN::TrainEnum::TrainRprop)
 ann.set_hidden_layer_activation_func(LibFANN::ActivationfuncEnum::Linear)
@@ -51,10 +51,10 @@ ann.close
 
 ```crystal
 # Work on array of test data using the Cascade2 algorithm (no hidden layers, net will build it alone)
-ann = Crystal::Fann::Network::Cascade.new(2, 1)
+ann = Fann::Network::Cascade.new(2, 1)
 input = [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
 output = [[0.0], [1.0], [1.0], [0.0]]
-train_data = Crystal::Fann::TrainData.new(input, output)
+train_data = Fann::TrainData.new(input, output)
 data = train_data.train_data
 ann.train_algorithem(LibFANN::TrainEnum::TrainRprop)
 ann.set_hidden_layer_activation_func(LibFANN::ActivationfuncEnum::Linear)

--- a/spec/network_spec.cr
+++ b/spec/network_spec.cr
@@ -1,23 +1,23 @@
 require "./spec_helper"
 
-describe Crystal::Fann::Network do
+describe Fann::Network do
   it "initializes standard network" do
-    ann = Crystal::Fann::Network::Standard.new(2, [2, 2], 2)
+    ann = Fann::Network::Standard.new(2, [2, 2], 2)
     ann.nn.is_a?(LibFANN::Fann*).should be_true
   end
 
   it "initializes cascade network" do
-    ann = Crystal::Fann::Network::Cascade.new(2, 2)
+    ann = Fann::Network::Cascade.new(2, 2)
     ann.nn.is_a?(LibFANN::Fann*).should be_true
   end
 
   it "free memory" do
-    ann = Crystal::Fann::Network::Standard.new(2, [2, 2], 2)
+    ann = Fann::Network::Standard.new(2, [2, 2], 2)
     ann.close
   end
 
   it "trains on single data" do
-    ann = Crystal::Fann::Network::Standard.new(2, [2, 2], 1)
+    ann = Fann::Network::Standard.new(2, [2, 2], 1)
     3000.times do
       ann.train_single([1.0, 0.0], [0.5])
     end
@@ -26,13 +26,13 @@ describe Crystal::Fann::Network do
   end
 
   it "Shows MSE" do
-    ann = Crystal::Fann::Network::Standard.new(2, [2, 2], 2)
+    ann = Fann::Network::Standard.new(2, [2, 2], 2)
     ann.mse.is_a?(LibC::Double).should be_true
     ann.close
   end
 
   it "trains and evaluate single data" do
-    ann = Crystal::Fann::Network::Standard.new(2, [2], 1)
+    ann = Fann::Network::Standard.new(2, [2], 1)
     3000.times do
       ann.train_single([1.0, 0.1], [0.5])
     end
@@ -42,10 +42,10 @@ describe Crystal::Fann::Network do
   end
 
   it "train on batch" do
-    ann = Crystal::Fann::Network::Standard.new(2, [3], 1)
+    ann = Fann::Network::Standard.new(2, [3], 1)
     input = [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
     output = [[0.0], [1.0], [1.0], [0.0]]
-    train_data = Crystal::Fann::TrainData.new(input, output)
+    train_data = Fann::TrainData.new(input, output)
     data = train_data.train_data
     ann.train_algorithem(LibFANN::TrainEnum::TrainRprop)
     # ann.set_hidden_layer_activation_func(LibFANN::ActivationfuncEnum::Linear)
@@ -59,10 +59,10 @@ describe Crystal::Fann::Network do
   end
 
   it "train on cascade" do
-    ann = Crystal::Fann::Network::Cascade.new(2, 1)
+    ann = Fann::Network::Cascade.new(2, 1)
     input = [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
     output = [[0.0], [1.0], [1.0], [0.0]]
-    train_data = Crystal::Fann::TrainData.new(input, output)
+    train_data = Fann::TrainData.new(input, output)
     data = train_data.train_data
     ann.train_algorithem(LibFANN::TrainEnum::TrainRprop)
     ann.set_hidden_layer_activation_func(LibFANN::ActivationfuncEnum::Linear)
@@ -76,10 +76,10 @@ describe Crystal::Fann::Network do
   end
 
   #it "train on multiple cores" do
-  #  ann = Crystal::Fann::Network::Standard.new(2, [3], 1)
+  #  ann = Fann::Network::Standard.new(2, [3], 1)
   #  input = [[0.0_f32, 0.0_f32], [0.0_f32, 1.0_f32], [1.0_f32, 0.0_f32], [1.0_f32, 1.0_f32]]
   #  output = [[0.0_f32], [1.0_f32], [1.0_f32], [0.0_f32]]
-  #  train_data = Crystal::Fann::TrainData.new(input, output)
+  #  train_data = Fann::TrainData.new(input, output)
   #  data = train_data.train_data
   #  ann.train_algorithem(LibFANN::TrainEnum::TrainRprop)
   #  # ann.set_hidden_layer_activation_func(LibFANN::ActivationfuncEnum::Linear)

--- a/spec/train_data_spec.cr
+++ b/spec/train_data_spec.cr
@@ -1,11 +1,11 @@
 require "./spec_helper"
 
-describe Crystal::Fann::Network do
+describe Fann::Network do
   it "initializes" do
     # initialize(input_array : Array(Array(Float64)), output_array : Array(Array(Float64)), max_input : Int32, max_output : Int32)
     input = [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
     output = [[0.0], [1.0], [1.0], [0.0]]
-    train_data = Crystal::Fann::TrainData.new(input, output)
-    (train_data.is_a?(Crystal::Fann::TrainData)).should be_true
+    train_data = Fann::TrainData.new(input, output)
+    (train_data.is_a?(Fann::TrainData)).should be_true
   end
 end

--- a/src/crystal-fann/cascade_network.cr
+++ b/src/crystal-fann/cascade_network.cr
@@ -1,4 +1,4 @@
-module Crystal::Fann
+module Fann
   module Network
     class Cascade
       property :nn

--- a/src/crystal-fann/standard_network.cr
+++ b/src/crystal-fann/standard_network.cr
@@ -1,4 +1,4 @@
-module Crystal::Fann
+module Fann
   module Network
     class Standard
       property :nn

--- a/src/crystal-fann/train_data.cr
+++ b/src/crystal-fann/train_data.cr
@@ -1,4 +1,4 @@
-module Crystal::Fann
+module Fann
   class TrainData
     property :data_struct, :p_input_array, :p_output_array
 

--- a/src/crystal-fann/version.cr
+++ b/src/crystal-fann/version.cr
@@ -1,3 +1,3 @@
-module Crystal::Fann
+module Fann
   VERSION = "0.1.0"
 end


### PR DESCRIPTION
Fixes #3 

```s/Crystal:://g``` :smile:

BTW, shouldn't the module be named FANN instead of Fann (following crystal's [coding style](https://crystal-lang.org/docs/conventions/coding_style.html))?