### PR TITLE
Add save and load methods

### DIFF
--- a/spec/network_spec.cr
+++ b/spec/network_spec.cr
@@ -77,7 +77,7 @@ describe Fann::Network do
     (result < [0.1]).should be_true
   end
 
-  context "#save" do
+  context "saving current network" do
     it "saves standard networks" do
       tempfile = Tempfile.new("foo")
       File.size(tempfile.path).should eq 0
@@ -95,14 +95,14 @@ describe Fann::Network do
     end
   end
 
-  context ".load" do
+  context "loading a configuration file" do
     it "loads standard networks" do
       input = 2
       output = 1
       tempfile = Tempfile.new("standard")
       original = Fann::Network::Standard.new(input, [2], output)
       original.save(tempfile.path)
-      loaded = Fann::Network::Standard.load(tempfile.path)
+      loaded = Fann::Network::Standard.new(tempfile.path)
       loaded.input_size.should eq input
       loaded.output_size.should eq output
     end
@@ -113,7 +113,7 @@ describe Fann::Network do
       tempfile = Tempfile.new("cascade")
       original = Fann::Network::Cascade.new(input, output)
       original.save(tempfile.path)
-      loaded = Fann::Network::Cascade.load(tempfile.path)
+      loaded = Fann::Network::Cascade.new(tempfile.path)
       loaded.input_size.should eq input
       loaded.output_size.should eq output
     end

--- a/spec/network_spec.cr
+++ b/spec/network_spec.cr
@@ -94,4 +94,28 @@ describe Fann::Network do
       (File.size(tempfile.path) > 0).should be_true
     end
   end
+
+  context ".load" do
+    it "loads standard networks" do
+      input = 2
+      output = 1
+      tempfile = Tempfile.new("standard")
+      original = Fann::Network::Standard.new(input, [2], output)
+      original.save(tempfile.path)
+      loaded = Fann::Network::Standard.load(tempfile.path)
+      loaded.input_size.should eq input
+      loaded.output_size.should eq output
+    end
+
+    it "loads cascade networks" do
+      input = 2
+      output = 1
+      tempfile = Tempfile.new("cascade")
+      original = Fann::Network::Cascade.new(input, output)
+      original.save(tempfile.path)
+      loaded = Fann::Network::Cascade.load(tempfile.path)
+      loaded.input_size.should eq input
+      loaded.output_size.should eq output
+    end
+  end
 end

--- a/spec/network_spec.cr
+++ b/spec/network_spec.cr
@@ -76,4 +76,22 @@ describe Fann::Network do
     ann.close
     (result < [0.1]).should be_true
   end
+
+  context "#save" do
+    it "saves standard networks" do
+      tempfile = Tempfile.new("foo")
+      File.size(tempfile.path).should eq 0
+      ann = Fann::Network::Standard.new(2, [2], 1)
+      ann.save(tempfile.path)
+      (File.size(tempfile.path) > 0).should be_true
+    end
+
+    it "saves cascade networks" do
+      tempfile = Tempfile.new("bar")
+      File.size(tempfile.path).should eq 0
+      ann = Fann::Network::Cascade.new(2, 1)
+      ann.save(tempfile.path)
+      (File.size(tempfile.path) > 0).should be_true
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,3 @@
 require "spec"
+require "tempfile"
 require "../src/crystal-fann"

--- a/src/crystal-fann/cascade_network.cr
+++ b/src/crystal-fann/cascade_network.cr
@@ -11,7 +11,8 @@ module Fann
         @nn = LibFANN.create_shortcut(2, input, output)
       end
 
-      def initialize(@nn)
+      def initialize(path : String)
+        @nn = LibFANN.create_from_file(path)
         @input_size = LibFANN.get_num_input(@nn)
         @output_size = LibFANN.get_num_output(@nn)
       end
@@ -53,11 +54,6 @@ module Fann
 
       def save(path : String) : Int32
         LibFANN.save(@nn, path)
-      end
-
-      def self.load(path : String)
-        nn = LibFANN.create_from_file(path)
-        new(nn)
       end
     end
   end

--- a/src/crystal-fann/cascade_network.cr
+++ b/src/crystal-fann/cascade_network.cr
@@ -2,11 +2,18 @@ module Fann
   module Network
     class Cascade
       property :nn
+      getter :input_size
+      getter :output_size
 
       def initialize(input : Int32, output : Int32)
         @output_size = output
         @input_size = input
         @nn = LibFANN.create_shortcut(2, input, output)
+      end
+
+      def initialize(@nn)
+        @input_size = LibFANN.get_num_input(@nn)
+        @output_size = LibFANN.get_num_output(@nn)
       end
 
       def mse
@@ -46,6 +53,11 @@ module Fann
 
       def save(path : String) : Int32
         LibFANN.save(@nn, path)
+      end
+
+      def self.load(path : String)
+        nn = LibFANN.create_from_file(path)
+        new(nn)
       end
     end
   end

--- a/src/crystal-fann/cascade_network.cr
+++ b/src/crystal-fann/cascade_network.cr
@@ -43,6 +43,10 @@ module Fann
         result = LibFANN.run(@nn, input.to_unsafe)
         Slice.new(result, @output_size).to_a
       end
+
+      def save(path : String) : Int32
+        LibFANN.save(@nn, path)
+      end
     end
   end
 end

--- a/src/crystal-fann/standard_network.cr
+++ b/src/crystal-fann/standard_network.cr
@@ -79,6 +79,10 @@ module Fann
         result = LibFANN.run(@nn, input.to_unsafe)
         Slice.new(result, @output_size).to_a
       end
+
+      def save(path : String) : Int32
+        LibFANN.save(@nn, path)
+      end
     end
   end
 end

--- a/src/crystal-fann/standard_network.cr
+++ b/src/crystal-fann/standard_network.cr
@@ -19,8 +19,9 @@ module Fann
         @nn = LibFANN.create_standard_array(layers.size, layers.to_unsafe)
       end
 
-      def initialize(@nn)
+      def initialize(path : String)
         @logger = Logger.new(STDOUT)
+        @nn = LibFANN.create_from_file(path)
         @input_size = LibFANN.get_num_input(@nn)
         @output_size = LibFANN.get_num_output(@nn)
       end
@@ -90,11 +91,6 @@ module Fann
 
       def save(path : String) : Int32
         LibFANN.save(@nn, path)
-      end
-
-      def self.load(path : String)
-        nn = LibFANN.create_from_file(path)
-        new(nn)
       end
     end
   end

--- a/src/crystal-fann/standard_network.cr
+++ b/src/crystal-fann/standard_network.cr
@@ -2,6 +2,8 @@ module Fann
   module Network
     class Standard
       property :nn
+      getter :input_size
+      getter :output_size
 
       def initialize(input : Int32, hidden : Array(Int32), output : Int32)
         @logger = Logger.new(STDOUT)
@@ -15,6 +17,12 @@ module Fann
         @input_size = input
 
         @nn = LibFANN.create_standard_array(layers.size, layers.to_unsafe)
+      end
+
+      def initialize(@nn)
+        @logger = Logger.new(STDOUT)
+        @input_size = LibFANN.get_num_input(@nn)
+        @output_size = LibFANN.get_num_output(@nn)
       end
 
       def mse
@@ -82,6 +90,11 @@ module Fann
 
       def save(path : String) : Int32
         LibFANN.save(@nn, path)
+      end
+
+      def self.load(path : String)
+        nn = LibFANN.create_from_file(path)
+        new(nn)
       end
     end
   end


### PR DESCRIPTION
This PR adds ```#save``` and ```.load``` methods to, respectively, save a given network configuration to a file and load a network from a given file.

Examples:

### Saving
```crystal
ann = Fann::Network::Standard.new(2, [2], 1)
500.times do
  ann.train_single([1.0, 0.1], [0.5])
end
result = ann.run([1.0, 0.1])
puts result
ann.save("/tmp/network.config")
ann.close
```

### Loading
```crystal
nn = Fann::Network::Standard.load("/tmp/test.save")
puts nn.run([1.0, 0.1])
```

Fixes #7.

WDYT @bararchy?